### PR TITLE
fixed bug where weapon status effects chance was never set

### DIFF
--- a/src/tactical/game/item/EquippableItem.java
+++ b/src/tactical/game/item/EquippableItem.java
@@ -219,6 +219,7 @@ public class EquippableItem extends Item
 		if (effectName != null)
 		{
 			eff = TacticalGame.ENGINE_CONFIGURATIOR.getBattleEffectFactory().createEffect(effectName, effectLevel);
+			eff.setEffectChance(effectChance);
 		}
 		return eff;
 	}


### PR DESCRIPTION
Effects are only given a name and level, the chance must be applied by setting the correct property.