### PR TITLE
Fixed Bug

### DIFF
--- a/src/tactical/game/battle/BattleResults.java
+++ b/src/tactical/game/battle/BattleResults.java
@@ -221,6 +221,9 @@ public class BattleResults implements Serializable
 		if (StringUtils.isEmpty(br.attackOverText))
 			br.attackOverText = null;
 	
+		if(br.critted.size() == 0)
+			br.critted.add(false);
+		
 		return br;
 	}
 

--- a/src/tactical/utils/planner/PlannerFrame.java
+++ b/src/tactical/utils/planner/PlannerFrame.java
@@ -273,6 +273,7 @@ public class PlannerFrame extends JFrame implements ActionListener,
 		JMenu cinematicMenu = new JMenu("Cinematic");
 		playCinematicMenuItem = addMenuItem("Play Cinematic", "playcin", cinematicMenu);
 		playCinematicMenuItem.setEnabled(false);
+		addMenuItem("Initialize Cinimatic Tab DropDown", "initCinDropDown", cinematicMenu);
 		menuBar.add(cinematicMenu);
 	}
 	
@@ -530,6 +531,10 @@ public class PlannerFrame extends JFrame implements ActionListener,
 		else if (actionCommand.equalsIgnoreCase("exportmap"))
 		{
 			// exportMap();
+		}
+		else if (actionCommand.equalsIgnoreCase("initCinDropDown"))
+		{
+			cinematicMapPanel.initializeCinematicIdList();
 		}
 		else if (actionCommand.equalsIgnoreCase("playcin")) {
 			if (cinematicMapPanel.getSelectedCinematicId() != -1) {


### PR DESCRIPTION
Bug when an enemy attacks sometimes the game would crash because of a index out of bound error.

While this solves the problem not sure if its the right solution. The battleresult.crited arraylist is supposed to have an item added to it when the battle is calculated, but sometimes in some branch no item ever gets added to the array list. I added code in the initilization of the battle result at the very end to make sure if the crited array list is empty that a false item is added to make sure it doesnt crash later.